### PR TITLE
Updated depreciated filter "login_headertitle" ...

### DIFF
--- a/login-logo.php
+++ b/login-logo.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Login Logo
 Description: Drop a PNG file named <code>login-logo.png</code> into your <code>wp-content</code> directory. This simple plugin takes care of the rest, with zero configuration. Transparent backgrounds work best. Crop it tight, with a width of 312 pixels, for best results.
-Version: 0.9.0
+Version: 0.10.0
 License: GPL
 Plugin URI: http://txfx.net/wordpress-plugins/login-logo/
 Author: Mark Jaquith
@@ -165,7 +165,7 @@ class CWS_Login_Logo_Plugin {
 		if ( !$this->logo_file_exists() )
 			return;
 		add_filter( 'login_headerurl', array( $this, 'login_headerurl' ) );
-		add_filter( 'login_headertitle', array( $this, 'login_headertitle' ) );
+		add_filter( version_compare( get_bloginfo( 'version' ), '5.2', '>=' ) ? 'login_headertext' : 'login_headertitle', array( $this, 'login_headertitle' ) );
 	?>
 	<!-- Login Logo plugin for WordPress: http://txfx.net/wordpress-plugins/login-logo/ -->
 	<style type="text/css">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "login-logo",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "login-logo",
   "title": "Login Logo",
   "description": "A WordPress plugin",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "homepage": "",
   "author": {
     "name": "Mark Jaquith",

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,7 @@ Contributors: markjaquith
 Donate link: http://txfx.net/wordpress-plugins/donate  
 Tags: customize, login, login screen, logo, custom logo  
 Requires at least: 3.3  
-Tested up to: 4.9.5  
+Tested up to: 5.2.1 
 
 Customize the logo on the WP login screen by simply dropping a file named login-logo.png into your WP content directory. CSS is automatic!
 
@@ -43,6 +43,10 @@ Your image is probably too wide. Wide images are scaled down in IE 9 or other mo
 
 
 ## Changelog ##
+
+### 0.10 ###
+* Updated depreciated filter "login_headertitle" to "login_headertext" with compatibility for older WordPress versions
+* Tested with WordPress 5.2.1
 
 ### 0.7 ###
 * The "title" attribute of the header link matches the WordPress site title instead of saying "Powered by WordPress".


### PR DESCRIPTION
* Updated depreciated filter "login_headertitle" to "login_headertext" with compatibility for older WordPress versions
* Tested with WordPress 5.2.1